### PR TITLE
Add option for background image resize

### DIFF
--- a/androidwm/src/main/java/com/watermark/androidwm/WatermarkBuilder.java
+++ b/androidwm/src/main/java/com/watermark/androidwm/WatermarkBuilder.java
@@ -45,6 +45,7 @@ public final class WatermarkBuilder {
     private Bitmap backgroundImg;
     private boolean isTileMode = false;
     private boolean isLSB = false;
+    private boolean resizeBackgroundImg;
     private BuildFinishListener<Bitmap> buildFinishListener = null;
 
     private WatermarkImage watermarkImage;
@@ -55,21 +56,47 @@ public final class WatermarkBuilder {
     /**
      * Constructors for WatermarkBuilder
      */
-    private WatermarkBuilder(@NonNull Context context, @NonNull Bitmap backgroundImg) {
+    private WatermarkBuilder(@NonNull Context context, @NonNull Bitmap backgroundImg, boolean resizeBackgroundImg) {
         this.context = context;
-        this.backgroundImg = resizeBitmap(backgroundImg, MAX_IMAGE_SIZE);
+        this.resizeBackgroundImg = resizeBackgroundImg;
+        if (resizeBackgroundImg) {
+            this.backgroundImg = resizeBitmap(backgroundImg, MAX_IMAGE_SIZE);
+        } else {
+            this.backgroundImg = backgroundImg;
+        }
     }
 
-    private WatermarkBuilder(@NonNull Context context, @NonNull ImageView backgroundImageView) {
+    private WatermarkBuilder(@NonNull Context context, @NonNull ImageView backgroundImageView, boolean resizeBackgroundImg) {
         this.context = context;
+        this.resizeBackgroundImg = resizeBackgroundImg;
         backgroundFromImageView(backgroundImageView);
     }
 
-    private WatermarkBuilder(@NonNull Context context, @DrawableRes int backgroundDrawable) {
+    private WatermarkBuilder(@NonNull Context context, @DrawableRes int backgroundDrawable, boolean resizeBackgroundImg) {
         this.context = context;
-        this.backgroundImg = resizeBitmap(BitmapFactory.decodeResource(context.getResources(),
-                backgroundDrawable), MAX_IMAGE_SIZE);
+        this.resizeBackgroundImg = resizeBackgroundImg;
+        if (resizeBackgroundImg) {
+            this.backgroundImg = resizeBitmap(BitmapFactory.decodeResource(context.getResources(),
+                    backgroundDrawable), MAX_IMAGE_SIZE);
+        } else {
+            this.backgroundImg = BitmapFactory.decodeResource(context.getResources(),
+                    backgroundDrawable);
+        }
+
     }
+
+    private WatermarkBuilder(@NonNull Context context, @NonNull Bitmap backgroundImg) {
+        this(context, backgroundImg, true);
+    }
+
+    private WatermarkBuilder(@NonNull Context context, @NonNull ImageView backgroundImageView) {
+        this(context, backgroundImageView, true);
+    }
+
+    private WatermarkBuilder(@NonNull Context context, @DrawableRes int backgroundDrawable) {
+        this(context, backgroundDrawable, true);
+    }
+
 
     /**
      * to get an instance form class.
@@ -101,6 +128,41 @@ public final class WatermarkBuilder {
     @SuppressWarnings("PMD")
     public static WatermarkBuilder create(Context context, @DrawableRes int backgroundDrawable) {
         return new WatermarkBuilder(context, backgroundDrawable);
+    }
+
+    /**
+     * to get an instance form class.
+     * with background image resize option
+     *
+     * @return instance of {@link WatermarkBuilder}
+     */
+    @SuppressWarnings("PMD")
+    public static WatermarkBuilder create(Context context, Bitmap backgroundImg, boolean resizeBackgroundImg) {
+        return new WatermarkBuilder(context, backgroundImg, resizeBackgroundImg);
+    }
+
+    /**
+     * to get an instance form class.
+     * Load the background image from a {@link ImageView}。
+     * with background image resize option
+     *
+     * @return instance of {@link WatermarkBuilder}
+     */
+    @SuppressWarnings("PMD")
+    public static WatermarkBuilder create(Context context, ImageView imageView, boolean resizeBackgroundImg) {
+        return new WatermarkBuilder(context, imageView, resizeBackgroundImg);
+    }
+
+    /**
+     * to get an instance form class.
+     * Load the background image from a DrawableRes。
+     * with background image resize option
+     *
+     * @return instance of {@link WatermarkBuilder}
+     */
+    @SuppressWarnings("PMD")
+    public static WatermarkBuilder create(Context context, @DrawableRes int backgroundDrawable, boolean resizeBackgroundImg) {
+        return new WatermarkBuilder(context, backgroundDrawable, resizeBackgroundImg);
     }
 
     /**
@@ -251,7 +313,11 @@ public final class WatermarkBuilder {
         imageView.invalidate();
         if (imageView.getDrawable() != null) {
             BitmapDrawable drawable = (BitmapDrawable) imageView.getDrawable();
-            backgroundImg = resizeBitmap(drawable.getBitmap(), MAX_IMAGE_SIZE);
+            if (resizeBackgroundImg) {
+                backgroundImg = resizeBitmap(drawable.getBitmap(), MAX_IMAGE_SIZE);
+            } else {
+                backgroundImg = drawable.getBitmap();
+            }
         }
     }
 

--- a/androidwm/src/main/java/com/watermark/androidwm/task/FDDetectionTask.java
+++ b/androidwm/src/main/java/com/watermark/androidwm/task/FDDetectionTask.java
@@ -28,7 +28,7 @@ import static com.watermark.androidwm.utils.Constant.CHUNK_SIZE;
 import static com.watermark.androidwm.utils.Constant.ERROR_BITMAP_NULL;
 import static com.watermark.androidwm.utils.Constant.ERROR_DETECT_FAILED;
 import static com.watermark.androidwm.utils.Constant.MAX_IMAGE_SIZE;
-import static com.watermark.androidwm.utils.Constant.WARNNING_BIG_IMAGE;
+import static com.watermark.androidwm.utils.Constant.WARNING_BIG_IMAGE;
 import static com.watermark.androidwm.utils.StringUtils.copyFromIntArray;
 
 /**
@@ -57,7 +57,7 @@ public class FDDetectionTask extends AsyncTask<Bitmap, Void, DetectionReturnValu
         }
 
         if (markedBitmap.getWidth() > MAX_IMAGE_SIZE || markedBitmap.getHeight() > MAX_IMAGE_SIZE) {
-            listener.onFailure(WARNNING_BIG_IMAGE);
+            listener.onFailure(WARNING_BIG_IMAGE);
             return null;
         }
 

--- a/androidwm/src/main/java/com/watermark/androidwm/task/LSBDetectionTask.java
+++ b/androidwm/src/main/java/com/watermark/androidwm/task/LSBDetectionTask.java
@@ -31,7 +31,7 @@ import static com.watermark.androidwm.utils.Constant.LSB_IMG_SUFFIX_FLAG;
 import static com.watermark.androidwm.utils.Constant.LSB_TEXT_PREFIX_FLAG;
 import static com.watermark.androidwm.utils.Constant.LSB_TEXT_SUFFIX_FLAG;
 import static com.watermark.androidwm.utils.Constant.MAX_IMAGE_SIZE;
-import static com.watermark.androidwm.utils.Constant.WARNNING_BIG_IMAGE;
+import static com.watermark.androidwm.utils.Constant.WARNING_BIG_IMAGE;
 import static com.watermark.androidwm.utils.StringUtils.binaryToString;
 import static com.watermark.androidwm.utils.StringUtils.getBetweenStrings;
 import static com.watermark.androidwm.utils.StringUtils.intArrayToStringJ;
@@ -62,7 +62,7 @@ public class LSBDetectionTask extends AsyncTask<Bitmap, Void, DetectionReturnVal
         }
 
         if (markedBitmap.getWidth() > MAX_IMAGE_SIZE || markedBitmap.getHeight() > MAX_IMAGE_SIZE) {
-            listener.onFailure(WARNNING_BIG_IMAGE);
+            listener.onFailure(WARNING_BIG_IMAGE);
             return null;
         }
 

--- a/androidwm/src/main/java/com/watermark/androidwm/utils/Constant.java
+++ b/androidwm/src/main/java/com/watermark/androidwm/utils/Constant.java
@@ -42,5 +42,5 @@ public class Constant {
     public static final String ERROR_NO_WATERMARK_FOUND = "No watermarks found in this image!";
     public static final String ERROR_BITMAP_NULL = "Cannot detect the watermark! markedBitmap is null object!";
 
-    public static final String WARNNING_BIG_IMAGE = "The input image may be too large to put into the memory, please be careful of the OOM!";
+    public static final String WARNING_BIG_IMAGE = "The input image may be too large to put into the memory, please be careful of the OOM!";
 }


### PR DESCRIPTION
Add option for background image resize, by adding a boolean parameter `resizeBackgroundImg` in `WatermarkBuilder.create()` method.

```
watermarkedImage = WatermarkBuilder
                .create(this, imageBitmap, false) // last param is resizeBackgroundImg
                .loadWatermarkText(watermarkText)
                .setTileMode(tileMode)
                ...
```

Existing code will work fine, since I just overloaded these methods.

Tested on my device and worked fine.

Note: I didn't set any limit about resizing when adding invisible watermark. As a result of this change, I suffered from major performance decrease when trying to **save** a visibly watermarked 4032*3024 PNG image (which took ~10s on my Pixel 2 XL). But drawing on `ImageView` seems fine.

Also there may be problems when reloading images to detect invisible watermark (I saw in code it would have `WARNING_BIG_IMAGE` when image is larger than `MAX_IMAGE_SIZE`). So I suggest that you could consider telling your users about this in `REDAME.MD`, or set some limit, up to your plans. (If you have any thoughts about this, I'm glad to help)